### PR TITLE
Fixed mobile orientation

### DIFF
--- a/docs/common.js
+++ b/docs/common.js
@@ -134,5 +134,5 @@ Y888888P  `Y88P'  `Y88P'  VP   V8P      YP   YP Y88888P Y88888P 88      Y88888P 
 */
 
 const getSVG = (name) => {
-    return '<svg><use href="/icons.svg#'+name+'"></use></svg>';
+    return '<svg><use href="./icons.svg#'+name+'"></use></svg>';
 }

--- a/docs/coursedisplay.css
+++ b/docs/coursedisplay.css
@@ -466,7 +466,7 @@ handle our hidings here
 
 
 
-@media (max-aspect-ratio: 5/4) or (orientation: portrait){
+@media (max-aspect-ratio: 5/4), (orientation: portrait){
 
     #course-info-container{
         position:relative;

--- a/docs/coursedisplay.css
+++ b/docs/coursedisplay.css
@@ -466,7 +466,7 @@ handle our hidings here
 
 
 
-@media (max-aspect-ratio: 1.25/1){
+@media (max-aspect-ratio: 5/4) or (orientation: portrait){
 
     #course-info-container{
         position:relative;

--- a/docs/coursedisplay.html
+++ b/docs/coursedisplay.html
@@ -81,25 +81,25 @@
 				<div id="key-panel">
 					<div id="yes-code" class="key-code">
 						<span class="code-icon" id="yes-code-icon">
-						<svg><use href="/icons.svg#circle-check"></use></svg>
+						<svg><use href="./icons.svg#circle-check"></use></svg>
 						</span>
 						Offered
 					</div>
 					<div id="no-code" class="key-code">
 						<span class="code-icon" id="no-code-icon">
-						<svg><use href="/icons.svg#circle-no"></use></svg>
+						<svg><use href="./icons.svg#circle-no"></use></svg>
 						</span>
 						Not Offered
 					</div>
 					<div id="diff-code" class="key-code">
 						<span class="code-icon" id="diff-code-icon">
-						<svg><use href="/icons.svg#circle-question"></use></svg>
+						<svg><use href="./icons.svg#circle-question"></use></svg>
 						</span>
 						Different Course Code
 					</div>
 					<div id="nil-code" class="key-code">
 						<span class="code-icon" id="nil-code-icon">
-						<svg><use href="/icons.svg#circle-empty"></use></svg>
+						<svg><use href="./icons.svg#circle-empty"></use></svg>
 						</span>
 						No Term Data
 					</div>


### PR DESCRIPTION
Added back in the `(orientation: portrait)` query. Seems like mobile browsers don't like `max-aspect-ratio` for whatever reason? idk, should be fixed now.